### PR TITLE
Implement @serializationIgnoreDefault

### DIFF
--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -783,6 +783,12 @@ unittest
 }
 
 /++
+Attribute to ignore a field when equals to its default value.
+Do not use it on void initialized fields or aggregates with void initialized fields, recursively.
++/
+enum Serialization serializationIgnoreDefault = serialization("ignore-default");
+
+/++
 Attribute to ignore field during deserialization.
 +/
 enum Serialization serializationIgnoreIn = serialization("ignore-in");

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -216,7 +216,6 @@ unittest
 	assert (deserialize!Foo(`{"my_nullable":200,"field":"it's a foo"}`) == Foo(MyNullable(200), "it's a foo"));
 
 	import std.typecons : Nullable;
-	import std.stdio;
 
 	static struct Bar
 	{
@@ -806,7 +805,7 @@ unittest
 		@serializationIgnoreDefault
 		Decor dec = Decor(20); // { 20, inf }
 	}
-	import std.stdio;
+	
 	assert(Cake("Normal Cake").serializeToJson == `{"name":"Normal Cake","slices":8,"flavor":1}`);
 	auto cake = Cake.init;
 	cake.dec = Decor.init;
@@ -1822,7 +1821,7 @@ void serializeValue(S, V)(ref S serializer, auto ref V value)
 			return;
 		}
 	}
-	
+
 	static if (hasSerializedAs!V)
 	{{
 		alias Proxy = getSerializedAs!V;


### PR DESCRIPTION
Resolve #137 - Allow default values to be ignored while serializing
Please check unittests carefully in case I missed something.