### PR TITLE
Add Serialization for our Units

### DIFF
--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1522,6 +1522,16 @@ void serializeValue(S, V)(ref S serializer, auto ref V value)
         value.serialize(serializer);
     }
     else
+    static if(__traits(hasMember, V, "toString"))
+    {
+        serializer.putValue(value.toString);
+    }
+    else
+    static if(__traits(hasMember, V, "getRawValue"))
+    {
+        serializer.putValue(value.getRawValue);
+    }
+    else
     {
         auto state = serializer.objectBegin();
         foreach(member; aliasSeqOf!(SerializableMembers!V))


### PR DESCRIPTION
- Add serialization for common unit functions: `toString` and `getRawValue`
- Based on `asdf`:`master`:`v0.7.1`