### PR TITLE
Fix crash on class deserialization

### DIFF
--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -428,6 +428,7 @@ unittest
 V deserialize(V)(Asdf data)
 {
     V value;
+    static if (is(V == class)) value = new V;
     if (auto exc = deserializeValue(data, value))
         throw exc;
     return value;
@@ -2281,6 +2282,7 @@ SerdeException deserializeValue(V : T[], T)(Asdf data, ref V value)
                 value = new T[elems.save.count];
                 foreach(ref e; value)
                 {
+                    static if(is(T == class)) e = new T;
                     if (auto exc = .deserializeValue(elems.front, e))
                         return exc;
                     elems.popFront;


### PR DESCRIPTION
In [Inochi2d](https://github.com/Inochi2D/inochi2d) we use asdf to deserialize internal JSON in to class objects, sometimes with arrays of classes. This makes Asdf _**not**_ segfault when doing so.