### PR TITLE
Prevent Serializing Empty Arrays as Null

### DIFF
--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1487,11 +1487,6 @@ unittest
 void serializeValue(S, T)(ref S serializer, T[] value)
     if(!isSomeChar!T)
 {
-    if(value is null)
-    {
-        serializer.putValue(null);
-        return;
-    }
     auto state = serializer.listBegin();
     foreach (ref elem; value)
     {


### PR DESCRIPTION
Consider the following example:
```d
import asdf;
struct S {
  int[] values;
}
string s = serializeToJson(S([]));
assert(s == "{\"values\": []}");
```
The assertion above fails because ASDF interprets an empty array as null, when a user would reasonably expect that if they provide an empty array to be serialized, that it should be represented in JSON as an empty array.

This pull request removes that check for null arrays, which is safe because dynamic arrays are not null in dRuntime, in the sense that you can iterate and get length and other properties of empty arrays.